### PR TITLE
fix load_resource examples

### DIFF
--- a/lib/load_resource.ex
+++ b/lib/load_resource.ex
@@ -44,11 +44,11 @@ These are all valid resource specifiers:
 
 The idea is that you create matching `load_resource` functions and rely Elixir’s function matching to select the right one.
 
-      def load_resource( assigns, :thing_a ) do
+      def load_resource( conn, :thins_a, assigns ) do
         {:ok, :thing_a, "data goes here"}
       end
       
-      def load_resource( assigns, {:thing_s, name} ) do
+      def load_resource( conn, {:thing_s, name}, assigns ) do
         {:ok, :thing_name, name}
       end
 


### PR DESCRIPTION
This PR corrects `load_resource/3` examples on `LoadResource` moduledoc.

The definitions need three args as described [here](https://github.com/boydm/policy_wonk/blob/c911f7d43cb0d512525a7f5170f897c270b7daa4/lib/loader.ex#L10)

Thanks.
