### PR TITLE
Be more discriminating when rescuing errors

### DIFF
--- a/lib/enforce.ex
+++ b/lib/enforce.ex
@@ -254,9 +254,7 @@ Both forms of `authorized?` simulate the policy finding found in the plug.
   #----------------------------------------------------------------------------
   defp call_policy( modules, assigns, policy ) do
     try do
-      Utils.call_down_list(modules, fn(module) ->
-        module.policy(assigns, policy)
-      end)
+      Utils.call_down_list(modules, {:policy, [assigns, policy]})
     catch
       # if a match wasn't found on the module, try the next in the list
       :not_found ->
@@ -273,9 +271,7 @@ Both forms of `authorized?` simulate the policy finding found in the plug.
   #----------------------------------------------------------------------------
   defp call_policy_error(modules, conn, err_data ) do
     try do
-      Utils.call_down_list(modules, fn(module) ->
-        module.policy_error(conn, err_data)
-      end)
+      Utils.call_down_list(modules, {:policy_error, [conn, err_data]})
     catch
       # if a match wasn't found on the module, try the next in the list
       :not_found ->

--- a/lib/load_resource.ex
+++ b/lib/load_resource.ex
@@ -218,9 +218,7 @@ If you do specify the module, then that is the only one `PolicyWonk.Enforce` wil
   #----------------------------------------------------------------------------
   defp call_loader( modules, conn, resource ) do
     try do
-      Utils.call_down_list(modules, fn(module) ->
-        module.load_resource(conn, resource, conn.params)
-      end)
+      Utils.call_down_list(modules, {:load_resource, [conn, resource, conn.params]})
     catch
       # if a match wasn't found on the module, try the next in the list
       :not_found ->
@@ -238,9 +236,7 @@ If you do specify the module, then that is the only one `PolicyWonk.Enforce` wil
   #----------------------------------------------------------------------------
   defp call_loader_error(modules, conn, err_data ) do
     try do
-      Utils.call_down_list(modules, fn(module) ->
-        module.load_error(conn, err_data)
-      end)
+      Utils.call_down_list(modules, {:load_error, [conn, err_data]})
     catch
       # if a match wasn't found on the module, try the next in the list
       :not_found ->

--- a/lib/utils.ex
+++ b/lib/utils.ex
@@ -6,7 +6,7 @@ defmodule PolicyWonk.Utils do
   @spec call_down_list(List.t, function) :: any
   def call_down_list( [], _callback ), do: throw :not_found
   def call_down_list( [nil | tail], callback ), do: call_down_list(tail, callback)
-  def call_down_list( [module | tail], {function, args} ) do
+  def call_down_list( [module | tail], {function, args} ) when is_atom(function) and is_list(args) do
     try do
       apply(module, function, args)
     rescue

--- a/test/enforce_test.exs
+++ b/test/enforce_test.exs
@@ -9,6 +9,7 @@ defmodule PolicyWonk.EnforceTest do
     def policy( _assigns, :suceeds_a ),        do: :ok
     def policy( _assigns, %{thing1: _one, thing2: _two} ),        do: :ok
     def policy( _assigns, :fails ),            do: "failed_policy"
+    def policy( _assigns, :raises ),            do: inspect( :something, :bad_argument )
 
     def policy_error(conn, "failed_policy"),  do: Plug.Conn.assign(conn, :errp, "failed_policy")
     def policy_error(_conn, "invalid"),       do: "invalid"
@@ -123,6 +124,14 @@ defmodule PolicyWonk.EnforceTest do
   test "call raises if policy not found", %{conn: conn} do
     opts = %{module: ModA, policies: [:missing]}
     assert_raise PolicyWonk.Enforce.PolicyError, fn ->
+      Enforce.call(conn, opts)
+    end
+  end
+
+  #----------------------------------------------------------------------------
+  test "call surfaces error raised inside policy", %{conn: conn} do
+    opts = %{module: ModA, policies: [:raises]}
+    assert_raise FunctionClauseError, fn ->
       Enforce.call(conn, opts)
     end
   end

--- a/test/load_resource_test.exs
+++ b/test/load_resource_test.exs
@@ -21,6 +21,9 @@ defmodule PolicyWonk.LoadResourceTest do
     def load_resource(_conn, %{name: name}, _params) do
       {:ok, :named_resource, name}
     end
+    def load_resource(_conn, :raises, _params) do
+      inspect( :something, :bad_argument )
+    end
 
 
     def load_error( conn, "invalid" ) do
@@ -229,6 +232,18 @@ defmodule PolicyWonk.LoadResourceTest do
       }
     conn = LoadResource.call(conn, opts)
     assert conn.status == 404
+  end
+
+  #----------------------------------------------------------------------------
+  test "call surfaces error raised inside load_resource", %{conn: conn} do
+    opts = %{
+      resources: [:raises],
+      module: ModA,
+      async: false         # From config
+    }
+    assert_raise FunctionClauseError, fn ->
+      LoadResource.call(conn, opts)
+    end
   end
 
 end

--- a/test/utils_test.exs
+++ b/test/utils_test.exs
@@ -21,32 +21,32 @@ defmodule PolicyWonk.UtilsTest do
 
   #----------------------------------------------------------------------------
   test "call_down_list calls modules in right order" do
-    assert Utils.call_down_list([ModA,ModB], &(&1.thingy(:generic)) ) == "generic_a"
-    assert Utils.call_down_list([ModB,ModA], &(&1.thingy(:generic)) ) == "generic_b"
+    assert Utils.call_down_list([ModA,ModB], {:thingy, [:generic]} ) == "generic_a"
+    assert Utils.call_down_list([ModB,ModA], {:thingy, [:generic]} ) == "generic_b"
   end
 
   #----------------------------------------------------------------------------
   test "call_down_list calls modules skips nil modules" do
-    assert Utils.call_down_list([nil,ModA,ModB], &(&1.thingy(:generic)) ) == "generic_a"
+    assert Utils.call_down_list([nil,ModA,ModB], {:thingy, [:generic]} ) == "generic_a"
   end
 
   #----------------------------------------------------------------------------
   test "call_down_list finds modules down the list" do
-    assert Utils.call_down_list([nil,ModA,nil,ModB], &(&1.thingy(:specific_a)) ) == "specific_a"
-    assert Utils.call_down_list([nil,ModA,nil,ModB], &(&1.thingy(:specific_b)) ) == "specific_b"
+    assert Utils.call_down_list([nil,ModA,nil,ModB], {:thingy, [:specific_a]} ) == "specific_a"
+    assert Utils.call_down_list([nil,ModA,nil,ModB], {:thingy, [:specific_b]} ) == "specific_b"
   end
 
   #----------------------------------------------------------------------------
   test "call_down_list throws :not_found on missing function" do
     assert catch_throw(
-      Utils.call_down_list([nil,ModA,nil,ModB], &(&1.missing(:generic)) )
+      Utils.call_down_list([nil,ModA,nil,ModB], {:missing, [:generic]} )
     ) == :not_found
   end
 
   #----------------------------------------------------------------------------
   test "call_down_list throws :not_found on missing match" do
     assert catch_throw(
-      Utils.call_down_list([nil,ModA,nil,ModB], &(&1.thingy(:missing)) )
+      Utils.call_down_list([nil,ModA,nil,ModB], {:thingy, [:missing]} )
     ) == :not_found
   end
 


### PR DESCRIPTION
This is a fix for #3 

Instead of passing a function callback to `Utils.call_down_list/2`, pass a {function, args} tuple. Now, when we rescue errors, we can check that they were raised by exactly the module/function/arity combination we were attempting, and re-raise the error in all other cases.

I wrapped the function and args in a tuple so that the new function clause would have the same arity as the one it replaced, but they could easily be separate parameters, or wrapped in a Map, or whatever.

Cheers!
