### PR TITLE
Allows authorized? to take an alternative authorization context

### DIFF
--- a/lib/policy.ex
+++ b/lib/policy.ex
@@ -329,8 +329,8 @@ defmodule PolicyWonk.Policy do
       * `policy` The policy or policies you want to enforce. This can be either a single
       term representing one policy, or a list of policy terms.
       """
-      def authorized?(conn, policies) do
-        PolicyWonk.Policy.authorized?(conn, __MODULE__, policies)
+      def authorized?(authorization_context, policies) do
+        PolicyWonk.Policy.authorized?(authorization_context, __MODULE__, policies)
       end
     end
 
@@ -403,18 +403,18 @@ defmodule PolicyWonk.Policy do
 
   # ----------------------------------------------------
   @doc false
-  def authorized?(conn, module, policies)
+  def authorized?(authorization_context, module, policies)
 
   # enforce? that a list of policies pass
   @doc false
-  def authorized?(%Plug.Conn{} = conn, module, policies) when is_list(policies) do
-    Enum.all?(policies, &authorized?(conn, module, &1))
+  def authorized?(%{assigns: assigns}, module, policies) when is_list(policies) do
+    Enum.all?(policies, &authorized?(%{assigns: assigns}, module, &1))
   end
 
   # enforce? a single policy
   @doc false
-  def authorized?(%Plug.Conn{} = conn, module, policy) do
-    case module.policy(conn.assigns, policy) do
+  def authorized?(%{assigns: assigns}, module, policy) do
+    case module.policy(assigns, policy) do
       :ok ->
         true
 

--- a/test/policy_test.exs
+++ b/test/policy_test.exs
@@ -104,6 +104,13 @@ defmodule PolicyWonk.PolicyTest do
   end
 
   # --------------------------------------------------------
+  test "use authorized?! returns true on policy success when not using a conn", %{conn: conn} do
+    authorization_context = %{assigns: conn.assigns}
+    assert ModA.authorized?(authorization_context, [:a]) == true
+    assert ModA.authorized?(authorization_context, :a) == true
+  end
+
+  # --------------------------------------------------------
   test "use authorized? raises on a failure", %{conn: conn} do
     assert ModA.authorized?(conn, [:fails]) == false
     assert ModA.authorized?(conn, :fails) == false
@@ -117,6 +124,13 @@ defmodule PolicyWonk.PolicyTest do
   test "authorized? uses the requested policy on the requested module", %{conn: conn} do
     assert Policy.authorized?(conn, ModA, [:a]) == true
     assert Policy.authorized?(conn, ModA, :a) == true
+  end
+
+  # --------------------------------------------------------
+  test "authorized? uses the requested policy on the requested module when not using a conn", %{conn: conn} do
+    authorization_context = %{assigns: conn.assigns}
+    assert Policy.authorized?(authorization_context, ModA, [:a]) == true
+    assert Policy.authorized?(authorization_context, ModA, :a) == true
   end
 
   # --------------------------------------------------------


### PR DESCRIPTION
Addresses Issue #10 

Allows `authorized?` functions to take a map with an `assigns` key as an authorization context. This would allow policies to be used in places like phoenix channels where a `Plug.Conn` is not present. This would even allow policies to be used outside of a web application context.

I didn't change other functions like `enforce` since they are more coupled to an actual `Plug.Conn` (in order to halt, etc)